### PR TITLE
Fix broken footer link to core team members page

### DIFF
--- a/templates/includes/footer.jade
+++ b/templates/includes/footer.jade
@@ -3,9 +3,9 @@ footer(role='contentinfo')
 
     nav(role='navigation')
       ul.unstyled
-        li 
+        li
           a(href='/updates', title='Latest Updates') Updates
-        li 
+        li
           a(href='/tutorials', title='Getting Started with hapi') Getting Started
         li
           a(href='/api', title='API Reference') API
@@ -15,6 +15,6 @@ footer(role='contentinfo')
           a(href='https://github.com/spumko/hapi', title='hapi on Github') Github
         li
           a(href='https://twitter.com/hapijs', title='@hapijs on Twitter') Twitter
-          
-    p hapi is maintained by the <a href='https://github.com/orgs/spumko/members'>core team</a> with help of <a href='https://github.com/spumko/hapi/graphs/contributors'>our contributors</a>.
+
+    p hapi is maintained by the <a href='https://github.com/orgs/spumko/people'>core team</a> with help of <a href='https://github.com/spumko/hapi/graphs/contributors'>our contributors</a>.
     p © 2011-2014, Walmart


### PR DESCRIPTION
The link in the footer to the core team members is broken. This should fix that.
