### PR TITLE
Added label example to plugins tutorial

### DIFF
--- a/tutorials/plugins.md
+++ b/tutorials/plugins.md
@@ -54,7 +54,13 @@ Several other methods and properties are available to plugins as well.
 
 #### `plugin.select()`
 
-As documented in the [getting started tutorial](/tutorials/getting-started), servers can be created with a label assigned to them. This label can then be used to apply plugins only to specific servers by using the `plugin.select()` method.
+Servers can be created with a label assigned to them:
+
+```javascript
+var server = new Hapi.Server({ labels: 'api' });
+```
+
+This label can then be used to apply plugins only to specific servers by using the `plugin.select()` method.
 
 For example, to add a route only to servers with a label of `'api'`, you would use:
 


### PR DESCRIPTION
In the Plugins tutorial it says:

> As documented in the [getting started tutorial](/tutorials/getting-started), servers can be created with a label assigned to them.

However there is no example of this in the Getting started tutorial. The Getting started tutorial is short and sweet and it'd be nice to keep it that way, so I've added an example of creating a server with a label inline in the Plugins tutorial.
