### PR TITLE
hapi-auth-signature plugin

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -19,6 +19,10 @@ exports.categories = {
         'hapi-auth-hawk': {
             url :'https://github.com/hapijs/hapi-auth-hawk',
             description: 'Hawk authentication plugin'
+        },
+        'hapi-auth-signature': {
+          url :'https://github.com/58bits/hapi-auth-signature',
+          description: 'Signature authentication plugin - a wrapper for the Joyent http-signature scheme'
         }
     },
     'Documentation': {


### PR DESCRIPTION
A signature auth plugin that's based on the Joyent http-signature
scheme. https://github.com/joyent/node-http-signature
