### PR TITLE
darken the text

### DIFF
--- a/style/globals/_colors.styl
+++ b/style/globals/_colors.styl
@@ -2,10 +2,9 @@
 * COLORS
 --------------------------------------------------------------------*/
 
-$gray = #434343
+$gray = #222
 $gray-light = lighten($gray, 35%)
 $gray-lighter = lighten($gray, 85%)
-$gray-dark = darken($gray, 50%)
 
 $green = #87997D
 $green-light = #C5E0B6


### PR DESCRIPTION
My eyes get tired when I read content on hapijs.com. Maybe I'm getting old, but I find the text is too light, especially on Chrome which renders the font very thinly. Firefox looks decent, but I don't really want to use Firefox.

This change makes the text a bit darker. That's all.
