### PR TITLE
Added 'Getting a cookie' to cookies.md

### DIFF
--- a/tutorials/cookies.md
+++ b/tutorials/cookies.md
@@ -47,6 +47,13 @@ reply('Hello').state('data', { firstVisit: false });
 
 In this example, hapi will reply with the string `Hello` as well as set a cookie named `data` to a base64 encoded string representation of the given object.
 
+## Getting a cookie
+Getting a cookie is done via the [`request` properties](/api#request-properties) through the `state` property, where each key is the cookie name.
+
+```javascript
+var myCookie = request.state.cookieName;
+```
+
 ### Overriding options
 
 When setting a cookie, you may also pass the same options available to `server.state()` as a third parameter, such as:


### PR DESCRIPTION
Hi, I miss a 'Getting a cookie'  in cookies.md
I asked myself "so it should probably be in...", may seem a bit obvious
but, maybe not.
