### PR TITLE
Changed list-style-type for list items nested 4 levels deep.

### DIFF
--- a/style/components/base.styl
+++ b/style/components/base.styl
@@ -137,6 +137,9 @@ ul, ol
     li
       list-style-type: square
 
+      ul li
+        list-style-type: disc
+
 ul
   li
     margin: 0 0 20px 0


### PR DESCRIPTION
This should help readability of API documentation.
With this change the list items nested 4 levels deep, won't have the same style as the ones nested 3 levels deep.
