### PR TITLE
Update homepage example

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,7 +19,8 @@ Create an `index.js` file with the following contents:
 var Hapi = require('hapi');
 
 // Create a server with a port number
-var server = new Hapi.Server(8000);
+var server = new Hapi.Server();
+server.connection({ port: 8000 });
 
 // Add the route
 server.route({


### PR DESCRIPTION
Currently using hapi 8.0 and homepage example you'll get `Error: Invalid server options "localhost"` as it's not taking host as a first parameter anymore.
