### PR TITLE
Update homepage example

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,7 +19,8 @@ Create an `index.js` file with the following contents:
 var Hapi = require('hapi');
 
 // Create a server with a host and port
-var server = new Hapi.Server('localhost', 8000);
+var server = new Hapi.Server();
+server.connection({ port: 8000 });
 
 // Add the route
 server.route({


### PR DESCRIPTION
In hapi 8.0 `Server` is taking options hash instead of `host, port` parameters.
