### PR TITLE
Fixed paths configuration of views tutorial

### DIFF
--- a/lib/tutorials/views.md
+++ b/lib/tutorials/views.md
@@ -92,7 +92,7 @@ server.views({
     engines: {
         html: require('handlebars')
     },
-    relativeTo __dirname,
+    relativeTo: __dirname,
     path: './views',
     layoutPath: './views/layout',
     helpersPath: './views/helpers'


### PR DESCRIPTION
Hi!

Small fix for a missing `:` in the path configuration object of the views tutorial.
