### PR TITLE
Add my rabbitMQ plugin

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -83,6 +83,12 @@ exports.categories = {
             description: 'Sends request round trip metrics to statsd'
         }
     },
+    'Messaging': {
+        'hapi-rabbit': {
+            url: 'https://github.com/aduis/hapi-rabbit',
+            description: 'A simple rabbitMQ integration plugin for hapi'
+        }
+    },
     'Security': {
         blankie: {
             url: 'https://github.com/nlf/blankie',


### PR DESCRIPTION
Hey, I've create a little rabbitMQ integration for hapi.js. It would be great if you guys would integrate hapi-rabbit into your plugin directory.
Thanks, Andre
