### PR TITLE
Add hapio plugin

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -205,6 +205,10 @@ exports.categories = {
         tv: {
             url: 'https://github.com/hapijs/tv',
             description: 'Interactive debug console plugin for hapi servers'
+        },
+        hapio: {
+            url: 'https://github.com/caligone/hapio',
+            description: 'A simple bridge plugin between HapiJS and SocketIO'
         }
     },
     Boilerplate: {


### PR DESCRIPTION
Hi there,

I just created a simple plugin to easily link hapi with socket.io.
I think it could be great to integrate it in the documentation.
