### PR TITLE
Correct the "routes" key in the optional registration options for a plugin (server.register())

### DIFF
--- a/lib/tutorials/plugins.md
+++ b/lib/tutorials/plugins.md
@@ -159,7 +159,7 @@ Normally, when this plugin is loaded it will create a `GET` route at `/test`. Th
 
 ```javascript
 server.register({register: require('myplugin')}, {
-    route: {
+    routes: {
         prefix: '/plugins'
     }
 }, function (err) {


### PR DESCRIPTION
The "routes" key is wrong in the current tutorial.
