### PR TITLE
Added airbrake-hapi as a new metrics/logging plugin.

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -81,6 +81,10 @@ exports.categories = {
         'hapi-statsd': {
             url: 'https://github.com/mac-/hapi-statsd',
             description: 'Sends request round trip metrics to statsd'
+        },
+        'airbrake-hapi': {
+	    url: 'https://github.com/Wayfarer247/airbrake-hapi',
+            description: 'Sends internal server errors to Airbrake.io'
         }
     },
     'Messaging': {


### PR DESCRIPTION
Hey Everyone,

Just finished up Version 1.0 of a plugin that captures Internal Server Errors and sends them to Airbrake.io. I'd love to see it on the [site](https://github.com/hapijs/hapijs.com/issues/7), let me know if there is anything else I need to do.

Thanks!