### PR TITLE
Add bedwetter and dogwater to plugins list.

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -132,6 +132,14 @@ exports.categories = {
             url: 'https://github.com/hapijs/bassmaster',
             description: 'The batch endpoint makes it easy to combine multiple requests into a single one'
         },
+        bedwetter: {
+            url: 'https://github.com/devinivy/bedwetter',
+            description: 'Auto-generated, CRUDdy route handlers for Waterline models in hapi'
+        },
+        dogwater: {
+            url: 'https://github.com/devinivy/dogwater',
+            description: 'A hapi plugin integrating Waterline ORM'
+        },
         halacious: {
             url: 'https://github.com/bleupen/halacious',
             description: 'A HAL processor for hapi servers'


### PR DESCRIPTION
Finally adding two of my plugins to the plugins list: dogwater, which integrates Waterline ORM (originally from the SailsJS project); and bedwetter, which is an API builder that is aware of Waterline models and their relationships.  They're both hapi8 ready, but compatible with hapi7.  If there are any issues here, just let me know, and I'll fix 'er up!  It looked like the plugins were mostly alphabetical, so I added these in alphabetically.