### PR TITLE
Add entry for hapi-auth-jwt2 simplified auth with JWT

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -35,6 +35,10 @@ exports.categories = {
         'hapi-auth-jwt': {
           url :'https://github.com/ryanfitz/hapi-auth-jwt',
           description: 'JSON Web Token (JWT) authentication plugin'
+        },        
+        'hapi-auth-jwt2': {
+          url :'https://www.npmjs.com/package/hapi-auth-jwt2',
+          description: 'Simplified JSON Web Token (JWT) authentication plugin'
         },
         'hapi-auth-signature': {
           url :'https://github.com/58bits/hapi-auth-signature',


### PR DESCRIPTION
Reduce the complexity in existing implementations and allow people to do their own checks in app-specific `validateFunc`
https://www.npmjs.com/package/hapi-auth-jwt2