### PR TITLE
Cookie Tutorial Update

### DIFF
--- a/lib/tutorials/cookies.md
+++ b/lib/tutorials/cookies.md
@@ -27,7 +27,7 @@ In addition to this, you may pass two parameters to the `config` when adding a r
 {
     config: {
         state: {
-            parse: true, // parse and store in request.cookies
+            parse: true, // parse and store in request.state
             failAction: 'error' // may also be 'ignore' or 'log'
         }
     }


### PR DESCRIPTION
Updates reference of `request.cookies` to `request.state`.

This was pointed out in hapijs/hapi#2042, but doesn't appear to have been addressed.