### PR TITLE
Update good-console example

### DIFF
--- a/lib/tutorials/getting-started.md
+++ b/lib/tutorials/getting-started.md
@@ -106,7 +106,10 @@ server.register({
     options: {
         reporters: [{
             reporter: require('good-console'),
-            args:[{ log: '*', response: '*' }]
+            events: {
+                request: '*',
+                log: '*'
+            }
         }]
     }
 }, function (err) {


### PR DESCRIPTION
Good 6.0.0 introduced some breaking changes that should be reflected in the tutorial. Note: good-console has a new version (5.0.0) which is compatible with good 6.0.0, however it is not published yet. I suggest to publish it before merging this PR.