### PR TITLE
Added hapi-io plugin

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -35,7 +35,7 @@ exports.categories = {
         'hapi-auth-jwt': {
           url :'https://github.com/ryanfitz/hapi-auth-jwt',
           description: 'JSON Web Token (JWT) authentication plugin'
-        },        
+        },
         'hapi-auth-jwt2': {
           url :'https://www.npmjs.com/package/hapi-auth-jwt2',
           description: 'Simplified JSON Web Token (JWT) authentication plugin'
@@ -179,6 +179,10 @@ exports.categories = {
         'hapi-dropbox-webhooks': {
             url: 'https://github.com/christophercliff/hapi-dropbox-webhooks',
             description: 'A Hapi plugin for receiving requests from the Dropbox webhooks API.'
+        },
+        'hapi-io': {
+            url: 'https://github.com/sibartlett/hapi-io',
+            description: 'A socket.io plugin that can forward socket.io events to hapi routes'
         },
         'hapi-level-db': {
             url: 'https://github.com/maxnachlinger/hapi-level-db',


### PR DESCRIPTION
I'm working on a [socket.io plugin](http://github.com/sibartlett/hapi-io) for hapi.

This plugin is different to others - it also has the ability to route socket.io events to hapi routes.