### PR TITLE
add hapi-server-session to plugins list

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -124,6 +124,10 @@ exports.categories = {
         }
     },
     'Session': {
+        'hapi-server-session': {
+            url: 'https://github.com/btmorex/hapi-server-session',
+            description: 'Simple server-side session support for hapi'
+        },
         yar: {
             url: 'https://github.com/hapijs/yar',
             description: 'A hapi session plugin and cookie jar'


### PR DESCRIPTION
Versus existing plugins:

* Never attempts to store session values in a cookie, only the uuid v4 session id
* Uses a diffing strategy to determine whether the session is dirty or not, which makes a nicer interface