### PR TITLE
Adds chat example app into resources section as per #198

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -60,6 +60,10 @@ exports.categories = {
         }
     },
     'Tutorials': {
+        'Building a Chat Application with hapi.js, Socket.io and Redis':{
+            url: 'https://github.com/dwyl/hapi-socketio-redis-chat-example',
+            description: 'Real-time chat application built using hapi.js, Socket.io and Redis Pub/Sub with end-to-end tests.'
+        },        
         'Using hapi.js with Socket.io': {
             url: 'http://matt-harrison.com/using-hapi-js-with-socket-io/',
             description: 'Tutorial on how to integrate Socket.io with hapi.js'


### PR DESCRIPTION
As discussed with @nlf and @nelsonic in issue #198, this PR adds a [real-time chat app example](https://github.com/dwyl/hapi-socketio-redis-chat-example) to the list of resources.

**Why is this a useful resource?**
+ Uses **hapi.js**! (most real-time node app examples out there use express)
+ End-to-end **tests**
+ Integrates socket.io
+ Uses redis **pub/sub** as an added bonus