### PR TITLE
Remove .task-list style rule. mdchangelog no longer adds this class. …

### DIFF
--- a/public/css/sections/github.styl
+++ b/public/css/sections/github.styl
@@ -92,7 +92,7 @@
     color: $orange-dark
 
 .changelog
-  ul.task-list
+  ul
     margin: 0
 
     li


### PR DESCRIPTION
…Fixes unwanted bullets on site.