### PR TITLE
Update plugins tutorial

### DIFF
--- a/lib/tutorials/plugins.md
+++ b/lib/tutorials/plugins.md
@@ -86,26 +86,18 @@ The return value of `server.select()` is a server object that contains only the 
 
 ## Loading a plugin
 
-Plugins can be loaded one at a time, or in a group, by the `server.register()` method, for example:
+Plugins can be loaded one at a time, or as a group in an array, by the `server.register()` method, for example:
 
 ```javascript
 // load one plugin
-server.register({register: require('myplugin')}, function (err) {
+server.register(require('myplugin'), function (err) {
     if (err) {
         console.error('Failed to load plugin:', err);
     }
 });
 
 // load multiple plugins
-server.register([
-    {
-        register: require('myplugin'),
-        options: {} // options for 'myplugin'
-    },{
-        register: require('yourplugin'),
-        options: {} // options for 'yourplugin'
-    }
-], function (err) {
+server.register([require('myplugin'), require('yourplugin')], function (err) {
     if (err) {
         console.error('Failed to load a plugin:', err);
     }


### PR DESCRIPTION
I have made a small suggested change to the plugins tutorial that clarifies the different ways the plugins can be registered. It was something I was not clear on at first and had to figure out a little myself.

I think this change makes it clearer that the simplest way to register a plugin is to pass register "a plugin registration function". Then progresses to an array of registration functions then expands that you can pass an object with register and options properties and then finally an array of these objects.

It seems also that this was the original intention of the tutorial.

I have only just started developing with Hapi in the last few days so I apologise if I have misunderstood something about the intention here.

I also note that you can mix functions and objects in the array but this is probably an uanessacry complication to add to this tutorial so I have not added an example of this.