### PR TITLE
add hapi-info

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -192,6 +192,10 @@ exports.categories = {
             url: 'https://github.com/christophercliff/hapi-dropbox-webhooks',
             description: 'A Hapi plugin for receiving requests from the Dropbox webhooks API.'
         },
+        'hapi-info': {
+            url: 'https://github.com/danielb2/hapi-info',
+            description: 'Adds route to show hapi version and plugin versions'
+        },
         'hapi-io': {
             url: 'https://github.com/sibartlett/hapi-io',
             description: 'A socket.io plugin that can forward socket.io events to hapi routes'


### PR DESCRIPTION
hapi-info adds route to show hapi version and plugin version

Added to utility section