### PR TITLE
Update Views tutorial to move server.views into callback

### DIFF
--- a/lib/tutorials/views.md
+++ b/lib/tutorials/views.md
@@ -1,5 +1,7 @@
 ## Views
 
+_This tutorial is compatible with hapi v9.x.x._
+
 hapi has extensive support for template rendering, including the ability to load and leverage multiple templating engines, partials, helpers (functions used in templates to manipulate data), and layouts.
 
 ## Configuring the server
@@ -13,16 +15,16 @@ var Hapi = require('hapi');
 var server = new Hapi.Server();
 
 server.register(require('vision'), function (err) {
-    if (err) {
-        console.log("Failed to load vision.");
-    }
-});
 
-server.views({
-    engines: {
-        html: require('handlebars')
-    },
-    path: Path.join(__dirname, 'templates')
+    Hoek.assert(!err, err);
+
+    server.views({
+        engines: {
+            html: require('handlebars')
+        },
+        relativeTo: __dirname,
+        path: 'templates'
+    });
 });
 
 ```
@@ -231,21 +233,26 @@ server.connection({
   host: "localhost"
 });
 
-server.views({
-  engines: {
-    html: require("handlebars")
-  },
-  relativeTo: __dirname,
-  path: "templates",
-  helpersPath: "helpers"
-});
+server.register(require('vision'), function (err) {
 
-server.route({
-  method: "GET",
-  path: "/",
-  handler: function(request, reply) {
-    reply.view("index");
-  }
+    Hoek.assert(!err, err);
+
+    server.views({
+      engines: {
+        html: require("handlebars")
+      },
+      relativeTo: __dirname,
+      path: "templates",
+      helpersPath: "helpers"
+    });
+
+    server.route({
+      method: "GET",
+      path: "/",
+      handler: function(request, reply) {
+        reply.view("index");
+      }
+    });
 });
 
 server.start();


### PR DESCRIPTION
Per discussion in https://github.com/hapijs/hapijs.com/pull/235. I followed the examples from https://github.com/hapijs/vision/blob/master/README.md. I also updated the other full example in the tutorial so I could add the compatibility notice to the top.