### PR TITLE
Add inert, h2o2, and vision to plugins

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -344,9 +344,17 @@ exports.categories = {
             url: 'https://github.com/hapijs/glue',
             description: 'Server composer'
         },
+        h2o2: {
+            url: 'https://github.com/hapijs/h2o2',
+            description: 'Proxy handler'
+        },
         hoek: {
             url: 'https://github.com/hapijs/hoek',
             description: 'General purpose node utilities'
+        },
+        inert: {
+            url: 'https://github.com/hapijs/inert',
+            description: 'Static file and directory handlers'
         },
         joi: {
             url: 'https://github.com/hapijs/joi',
@@ -379,6 +387,10 @@ exports.categories = {
         topo: {
             url: 'https://github.com/hapijs/topo',
             description: 'Topological sorting with grouping support'
+        },
+        vision: {
+            url: 'https://github.com/hapijs/vision',
+            description: 'Templates rendering support'
         },
         wreck: {
             url: 'https://github.com/hapijs/wreck',


### PR DESCRIPTION
https://github.com/hapijs/hapijs.com/issues/225. I added everything under `The extended hapi universe` since there is some inconsistency as to where first party plugins should go. For example, `good` is under logging while `joi` is not under `Validation`.