### PR TITLE
dynamically set height of nav while scrolling

### DIFF
--- a/public/css/sections/api.styl
+++ b/public/css/sections/api.styl
@@ -14,7 +14,7 @@
     height: 100%
 
     nav
-      height: 100%
+      height: calc(100% - 135px)
       overflow: auto
     
       & > ul

--- a/public/css/sections/api.styl
+++ b/public/css/sections/api.styl
@@ -14,7 +14,7 @@
     height: 100%
 
     nav
-      height: calc(100% - 135px)
+      height: 100%
       overflow: auto
     
       & > ul

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -53,16 +53,23 @@ var windowHandler = function () {
             var left = (winWidth * 0.1) + (winWidth * 0.8 * 0.7);
             var width = winWidth * 0.8 * 0.3;
 
+            var contentCol = document.querySelector('.column');
+            var height = contentCol.offsetHeight - (top - headerBottom);
+
             navDiv.style.position = 'fixed';
             navDiv.style.top = 0;
             navDiv.style.left = left + 'px';
             navDiv.style.width = width + 'px';
+            navDiv.style.height = height + 'px';
+            navDiv.style.minHeight = height + 'px';
         }
         else {
             navDiv.style.position = '';
             navDiv.style.top = '';
             navDiv.style.left = '';
             navDiv.style.width = '';
+            navDiv.style.height = '';
+            navDiv.style.minHeight = '';
         }
     }
 };


### PR DESCRIPTION
Another attempt to fix #215 without reorganizing any elements

as you scroll and the nav becomes fixed, its height will now be set to match the remaining height of its partner column (the one with all the content). when you get to the footer, all links will be clickable. if the sidebar overflows, it becomes scrollable so you can still access the content.