### PR TITLE
Added hapi-rbac to the list of plugins

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,4 +1,10 @@
 exports.categories = {
+    'Authorization': {
+        'hapi-rbac': {
+            url: 'https://github.com/franciscogouveia/hapi-rbac',
+            description: 'A Rule Based Access Control module for hapi.'
+        }
+    },
     'Authentication': {
         bell: {
             url: 'https://github.com/hapijs/bell',


### PR DESCRIPTION
This is a rule based access control for hapi. It allows one to define access control rules to routes.