### PR TITLE
Add `hapi-heroku-helpers`

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -196,6 +196,10 @@ exports.categories = {
             url: 'https://github.com/christophercliff/hapi-dropbox-webhooks',
             description: 'A Hapi plugin for receiving requests from the Dropbox webhooks API.'
         },
+        'hapi-heroku-helpers': {
+            url: 'https://github.com/briandela/hapi-heroku-helpers',
+            description: 'A hapi.js plugin which provides some basic functionality which can be useful when running a hapi.js site on Heroku.'
+        },
         'hapi-info': {
             url: 'https://github.com/danielb2/hapi-info',
             description: 'Adds route to show hapi version and plugin versions'


### PR DESCRIPTION
Add the `hapi-herku-helpers` plugin to the http://hapijs.com/plugins page.