### PR TITLE
Add Glee to list of Hapi plugins

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -53,7 +53,7 @@ exports.categories = {
         'hapi-passport-saml': {
             url: 'https://github.com/molekilla/hapi-passport-saml',
             description: 'A Hapi plugin that wraps passport-saml for SAML SSO'
-        },        
+        },
         'hapi-session-mongo': {
             url: 'https://github.com/Mkoopajr/hapi-session-mongo',
             description: 'MongoDB session store and authentication plugin'
@@ -173,6 +173,10 @@ exports.categories = {
         dogwater: {
             url: 'https://github.com/devinivy/dogwater',
             description: 'A hapi plugin integrating Waterline ORM'
+        },
+        glee: {
+          url: 'https://github.com/nathanbuchar/hapi-glee',
+          description: 'Specify environment-specific scopes for your routes.'
         },
         halacious: {
             url: 'https://github.com/bleupen/halacious',


### PR DESCRIPTION
Uses minimatch to allow you to register your routes based on a particular node environment set when registering the plugin.