### PR TITLE
Add crudy to utilities

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -170,6 +170,10 @@ exports.categories = {
             url: 'https://github.com/devinivy/bedwetter',
             description: 'Auto-generated, CRUDdy route handlers for Waterline models in hapi'
         },
+        crudy: {
+            url : 'https://github.com/g-div/crudy',
+            description: 'Exposes a RESTful CRUD interface using Dogwater models and Bedwetter\'s route-handler'
+        },
         dogwater: {
             url: 'https://github.com/devinivy/dogwater',
             description: 'A hapi plugin integrating Waterline ORM'


### PR DESCRIPTION
Crudy will expose a RESTful CRUD interface using your Dogwater models and Bedwetter's route-handler.