### PR TITLE
Adding Hoek dependency to views tutorial

### DIFF
--- a/lib/tutorials/views.md
+++ b/lib/tutorials/views.md
@@ -11,6 +11,7 @@ To get started with views, first we have to configure at least one templating en
 ```javascript
 var Path = require('path');
 var Hapi = require('hapi');
+var Hoek = require('hoek');
 
 var server = new Hapi.Server();
 


### PR DESCRIPTION
The Hoek import in the views tutorial is missing. Adding it in so the code works with no errors.