### PR TITLE
Add hanx.js to resources.js

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -51,6 +51,10 @@ exports.categories = {
         rutha: {
             url: 'https://github.com/molekilla/rutha',
             description: 'frontend stack for hapi (server, api) and Angular (client)'
+        },
+        'hanx.js': {
+            url: 'https://github.com/youhusam/hanx.js',
+            description: 'Full-stack boilerplate with Node.js, hapi, PostgreSQL and AngularJS (MEAN.js port)'
         }
     },
     'Projects built with hapi.js': {


### PR DESCRIPTION
I ported mean.js into hapi and I would like to have it on the list of boilerplates on the hapijs website