### PR TITLE
Add link to App Engine tutorial. Add Google Inc. to list of copyright owners.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 Copyright (c) 2011-2015, Eran Hammer and other contributors.
 Copyright (c) 2011-2014, Walmart.
 Copyright (c) 2011, Yahoo Inc.
+Copyright (c) 2015, Google Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -27,6 +28,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
                                   *   *   *
 
-The complete list of contributors can be found at: https://github.com/hapijs/hapi/graphs/contributors
+The complete list of contributors can be found at: https://github.com/hapijs/hapijs.com/graphs/contributors
 Portions of this project were initially based on the Yahoo! Inc. Postmile project,
 published at https://github.com/yahoo/postmile.

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -87,6 +87,10 @@ exports.categories = {
         'How to create a REST API with hapi': {
             url: 'http://blog.webkid.io/how-to-create-a-rest-api-with-hapi/',
             description: 'Tutorial about how to create a RESTful API with the Plugins Dogwater (Waterline ORM) and Bedwetter.'
+        },
+        'Run Hapi.js on Google Cloud Platform': {
+            url: 'https://cloud.google.com/nodejs/resources/frameworks/hapi',
+            description: 'Tutorial and cloneable sample app showing how to create and deploy a Hapi.js application on Google App Engine.'
         } 
     },
     'Videos': {


### PR DESCRIPTION
We love Hapi.js and wrote a simple getting started tutorial for deploying your Hapi.js app to Google App Engine. This PR adds a link to that tutorial in Hapi's list of links to examples/tutorials.

Our [sample app](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/tree/master/appengine/hapi) is on GitHub, and we'd love any feedback/contributions.