### PR TITLE
Update plugins.js

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -171,6 +171,10 @@ exports.categories = {
         'hapi-react-views': {
             url: 'https://github.com/jedireza/hapi-react-views',
             description: 'A hapi view engine for React components.'
+        },
+        'hapi-react-handler': {
+            url: 'https://github.com/tanepiper/hapi-react-handler',
+            description: 'A route handler that uses react-router to create routes and serve isomorphic react templates'
         }
     },
     'Utility': {


### PR DESCRIPTION
Added a line for hapi-react-handler. This is different to the hapi-react-views plugin in that is specifically uses react-router to take paths and render files from a resolved router handler.