### PR TITLE
Update hapi-react-handler to quorra

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -172,9 +172,9 @@ exports.categories = {
             url: 'https://github.com/jedireza/hapi-react-views',
             description: 'A hapi view engine for React components.'
         },
-        'hapi-react-handler': {
-            url: 'https://github.com/tanepiper/hapi-react-handler',
-            description: 'A route handler that uses react-router to create routes and serve isomorphic react templates'
+        '@tanepiper/quorra': {
+            url: 'https://github.com/tanepiper/quorra',
+            description: 'Hapi route handler that makes react-router your isomorphic server side router.'
         }
     },
     'Utility': {


### PR DESCRIPTION
Now points to correct repo for this as a 1.0.0 release.  Also this is a scoped module on npm.