### PR TITLE
Add hapi-algolia-search

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -206,6 +206,10 @@ exports.categories = {
             url: 'https://github.com/bleupen/halacious',
             description: 'A HAL processor for hapi servers'
         },
+        'hapi-algolia-search': {
+            url: 'https://github.com/sigfox/hapi-algolia-search',
+            description: 'A hapi plugin intergation Algolia Search (a earch engine as a service)'
+        },
         'hapi-assets': {
             url: 'https://github.com/poeticninja/hapi-assets',
             description: 'Load assets in views based on node environment.'


### PR DESCRIPTION
A hapi plugin wrapping the AlgoliaSearch javascript client