### PR TITLE
Hapi Server on OpenShift

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -69,9 +69,8 @@ exports.categories = {
             description: 'A Boilerplate that help you to create fast project with Hapi + MongoDB'
         },
         'snowflake-hapi-openshift': {
-          url: 'https://github.com/bartonhammond/snowflake-hapi-openshift',
-            description: 'Hapi Server running on OpenShift/local backed by'
-            + ' MongoDB & Redis - Performance Tested with BlazeMeter & JMeter'
+            url: 'https://github.com/bartonhammond/snowflake-hapi-openshift',
+            description: 'Hapi Server running on OpenShift/local backed by MongoDB & Redis - Performance Tested with BlazeMeter & JMeter'
         }
     },
     'Projects built with hapi.js': {

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -67,6 +67,11 @@ exports.categories = {
         'start-hapiness': {
             url: 'https://github.com/thebergamo/start-hapiness',
             description: 'A Boilerplate that help you to create fast project with Hapi + MongoDB'
+        },
+        'snowflake-hapi-openshift': {
+          url: 'https://github.com/bartonhammond/snowflake-hapi-openshift',
+            description: 'Hapi Server running on OpenShift/local backed by'
+            + ' MongoDB & Redis - Performance Tested with BlazeMeter & JMeter'
         }
     },
     'Projects built with hapi.js': {


### PR DESCRIPTION
See YouTube playlist: [https://www.youtube.com/channel/UCYjEEr8mSGhHS2FI0L1tMEg/playlists](https://www.youtube.com/channel/UCYjEEr8mSGhHS2FI0L1tMEg/playlists) - it shows the commands to install on OpenShift.  The project is fully documented with instructions and code walkthrough.

Hapi with MongoDB for User and Redis for "Blacklisted JWToken".  Includes Swagger for API documentation.

Initially created as server for React Native project: [https://github.com/bartonhammond/snowflake](https://github.com/bartonhammond/snowflake)
