### PR TITLE
add tools section to resources with glue and hapi-runplugin

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -95,6 +95,20 @@ exports.categories = {
             description: 'A HTML5 multiplayer game, based on the popular board game "Catan" by Klaus Teuber.'
         }
     },
+    'Tools': {
+        'glue': {
+            url: 'https://github.com/hapijs/glue',
+            description: 'Glue provides configuration based composition of hapi\'s Server object.'
+        },
+        'rejoice': {
+            url: 'https://github.com/hapijs/rejoice',
+            description: 'Rejoice is a CLI tool for hapi which requires a js/json file with the config. It relies on the composer library glue.'
+        },
+        'hapi-runplugin': {
+            url: 'https://github.com/danielb2/hapi-runplugin',
+            description: 'Runs a hapi server using the specified plugin and outputs route info to console. Useful for displaying route info and testing/interfacing with the plugin.'
+        },
+    },
     'Tutorials': {
         'Building a Chat Application with hapi.js, Socket.io and Redis': {
             url: 'https://github.com/dwyl/hapi-socketio-redis-chat-example',


### PR DESCRIPTION
Ref: https://github.com/hapijs/hapijs.com/issues/339

A section for tools such as glue, rejoice and hapi-runplugin that aren't plugins but should not be overlooked in the hapi ecosystem. 
