### PR TITLE
Add hodgepodge and loveboat to plugins page

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -378,6 +378,14 @@ exports.categories = {
             url: 'https://github.com/atroo/hapi-webpack-dev-server-plugin',
             description: 'Implementation of the dev server middleware to function as a plugin in a hapi.js server'
         },
+        hodgepodge: {
+            url: 'https://github.com/devinivy/hodgepodge',
+            description: 'A plugin dependency resolver'
+        },
+        loveboat: {
+            url: 'https://github.com/devinivy/loveboat',
+            description: 'A pluggable route configuration preprocessor'
+        },
         mrhorse: {
             url: 'https://github.com/mark-bradshaw/mrhorse',
             description: 'Plugin for adding pre-handlers and post-handlers to routes'


### PR DESCRIPTION
The only strangeness here is that hodgepodge is a utility but not a plugin.

Adding,
https://github.com/devinivy/hodgepodge
https://github.com/devinivy/loveboat