### PR TITLE
Add Paydash to projects built with hapi.js

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -93,6 +93,10 @@ exports.categories = {
         'Colonizers': {
             url: 'https://github.com/colonizers/colonizers',
             description: 'A HTML5 multiplayer game, based on the popular board game "Catan" by Klaus Teuber.'
+        },
+        'Paydash': {
+            url: 'https://github.com/hks-epod/paydash',
+            description: 'Worker payments dashboard for MGNREGA, India\'s employment guarantee programme.'
         }
     },
     'Tutorials': {


### PR DESCRIPTION
Paydash is a monitoring tool for block officials overseeing MGNREGA, India's employment guarantee programme for rural households. Built with hapi.js and hapi.js's extended universe.