### PR TITLE
Removed hapil18n from the plugins section

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -94,10 +94,6 @@ exports.categories = {
             url: 'https://github.com/maxnachlinger/hapi-l10n-gettext',
             description: 'A localization plug-in for HapiJS'
         },
-        hapil18n: {
-            url: 'https://github.com/gpierret/hapi18n',
-            description: 'i18n for Hapi'
-        },
         'hapi-accept-language': {
             url: 'https://github.com/opentable/hapi-accept-language',
             description: 'simple accept-language header parsing'


### PR DESCRIPTION
Removed hapil18n from the "Localization/Internationalization" plugins section because the url lands on a 404.

issue: #346