### PR TITLE
add new hapi-plugin-co: Co-routine based route handlers 

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -342,6 +342,10 @@ exports.categories = {
             url: 'https://github.com/fknop/hapi-pagination',
             description: 'A simple / customizable pagination plugin for HapiJS'
         },
+        'hapi-plugin-co': {
+            url: 'https://github.com/rse/hapi-plugin-co',
+            description: 'Co-routine based route handlers for asynchronous processing'
+        },
         'hapi-plugin-header': {
             url: 'https://github.com/rse/hapi-plugin-header',
             description: 'Always send one or more custom HTTP headers, independent of the current route'


### PR DESCRIPTION
This adds my plugin "hapi-plugin-co" for co-routine based route handlers for asynchronous processing. The difference between this and the plugins "hapi-async-handler" and "hapi-co" are stated in the README of the project, too.