### PR TITLE
Added hapi-graceful-pm2

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -550,6 +550,10 @@ exports.categories = {
             url: 'https://github.com/hapijs/h2o2',
             description: 'Proxy handler'
         },
+        hapi-graceful-pm2: {
+            url: 'https://github.com/roylines/hapi-graceful-pm2',
+            description: 'Handle true zero downtime reloads when issuing a pm2 gracefulReload command'
+        },
         hoek: {
             url: 'https://github.com/hapijs/hoek',
             description: 'General purpose node utilities'


### PR DESCRIPTION
This is a hapi plugin to handle true zero downtime reloads when issuing a pm2 gracefulReload command.

When using this plugin and calling 'pm2 gracefulReload', the 'shutdown' message will be intercepted and will wait for hapi to drain all connections before exiting the worker. This will ensure any in progress requests are completed before exiting. Whilst waiting, no new requests will be forwarded to the worker.