### PR TITLE
provide default monospace font

### DIFF
--- a/public/css/globals/_variables.styl
+++ b/public/css/globals/_variables.styl
@@ -5,7 +5,7 @@
 /* Typefaces */
 
 $font-facit = 'jaf-facitweb', 'Helvetica Neue', Helvetica, Arial, sans-serif
-$font-inconsolata = 'inconsolata', menlo, consolas, monospaced
+$font-inconsolata = 'inconsolata', menlo, consolas, monospace
 
 /* Font Sizes */
 


### PR DESCRIPTION
On my ubuntu machine, the lack of the default "monospace" CSS font-family gives me code in some serif font :-(