### PR TITLE
Added link to epimetheus: a plugin for prometheus instrumentation

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -116,6 +116,10 @@ exports.categories = {
             url: 'https://github.com/danielb2/blipp',
             description: 'Displays the routes table at startup'
         },
+        epimetheus: {
+            url: 'https://github.com/roylines/node-epimetheus',
+            description: 'Key metrics instrumentation for prometheus.io monitoring solution '
+        },
         good: {
             url: 'https://github.com/hapijs/good',
             description: 'A logging plugin that supports output to console, file and udp/http endpoints'


### PR DESCRIPTION
A plugin to automatically instrument node applications for consumption by a Prometheus server.

Prometheus is an open source monitoring solution that obtains metrics from servers by querying against the /metrics endpoint upon them.

Once instrumented, Epimetheus automatically serves response duration, event loop lag and memory metrics on the /metrics endpoint ready to be consumed by Prometheus.