### PR TITLE
Add labbable to utilities list

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -446,6 +446,10 @@ exports.categories = {
             url: 'https://github.com/thebergamo/k7',
             description: 'Connect you database with Hapijs made easy'
         },
+        labbable: {
+            url: 'https://github.com/devinivy/labbable',
+            description: 'No-fuss hapi server testing'
+        },
         loveboat: {
             url: 'https://github.com/devinivy/loveboat',
             description: 'A pluggable route configuration preprocessor'


### PR DESCRIPTION
Yet more tools 🔨 

Makes your server "labbable" i.e. more easy to pass into your tests, especially for use with glue.