### PR TITLE
Add haps-attempts-limiter to plugin list

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -277,6 +277,10 @@ exports.categories = {
             url: 'https://github.com/ide/hapi-async-handler',
             description: 'Use ES7 async functions and co generator functions as hapi route handlers'
         },
+        'hapi-attempts-limiter': {
+            url: 'https://github.com/acavestro/hapi-attempts-limiter',
+            description: 'An hapi.js plugin that limits the number of failed attempts for every route'
+        },
         'hapi-bookshelf-models': {
             url: 'https://github.com/lob/hapi-bookshelf-models',
             description: 'Load, register, and expose Bookshelf.js models'


### PR DESCRIPTION
Hi, 
recently I wrote a plugin for Hapi.js and I would like to add it to Hapi's plugin list.

Feel free to comment my work, any opinion, suggestion or criticism is always well accepted!

Bye
Antonio