### PR TITLE
adds information on how to clear a cookie

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -68,7 +68,7 @@ exports.categories = {
         'hapi-session-mongo': {
             url: 'https://github.com/Mkoopajr/hapi-session-mongo',
             description: 'MongoDB session store and authentication plugin'
-        }, 
+        },
         'hapi-tiny-auth': {
             url: 'https://github.com/elnaz/hapi-tiny-auth',
             description: 'Just enough authentication to make an API private'

--- a/lib/tutorials/en_US/cookies.md
+++ b/lib/tutorials/en_US/cookies.md
@@ -50,7 +50,7 @@ In this example, hapi will reply with the string `Hello` as well as set a cookie
 The cookie can be cleared by calling the `unstate()` method on the [`response`](/api#response-object) object:
 
 ```javascript
-reply('Hello').unstate('data', { firstVisit: false });
+reply('Hello').unstate('data');
 ```
 
 ### Overriding options
@@ -59,6 +59,3 @@ When setting a cookie, you may also pass the same options available to `server.s
 
 ```javascript
 reply('Hello').state('data', 'test', { encoding: 'none' });
-```
-
-When clearing a cookie, the specified keys in options must match the same keys in the server definition.  

--- a/lib/tutorials/en_US/cookies.md
+++ b/lib/tutorials/en_US/cookies.md
@@ -50,7 +50,7 @@ In this example, hapi will reply with the string `Hello` as well as set a cookie
 The cookie can be cleared by calling the `unstate()` method on the [`response`](/api#response-object) object:
 
 ```javascript
-reply('Hello').unstate('data', { firstVisit: false});
+reply('Hello').unstate('data', { firstVisit: false });
 ```
 
 ### Overriding options

--- a/lib/tutorials/en_US/cookies.md
+++ b/lib/tutorials/en_US/cookies.md
@@ -46,6 +46,14 @@ reply('Hello').state('data', { firstVisit: false });
 
 In this example, hapi will reply with the string `Hello` as well as set a cookie named `data` to a base64 encoded string representation of the given object.
 
+### Overriding options
+
+When setting a cookie, you may also pass the same options available to `server.state()` as a third parameter, such as:
+
+```javascript
+reply('Hello').state('data', 'test', { encoding: 'none' });
+```
+
 ## Clearing a cookie
 The cookie can be cleared by calling the `unstate()` method on the [`response`](/api#response-object) object:
 
@@ -53,9 +61,3 @@ The cookie can be cleared by calling the `unstate()` method on the [`response`](
 reply('Hello').unstate('data');
 ```
 
-### Overriding options
-
-When setting a cookie, you may also pass the same options available to `server.state()` as a third parameter, such as:
-
-```javascript
-reply('Hello').state('data', 'test', { encoding: 'none' });

--- a/lib/tutorials/en_US/cookies.md
+++ b/lib/tutorials/en_US/cookies.md
@@ -46,6 +46,13 @@ reply('Hello').state('data', { firstVisit: false });
 
 In this example, hapi will reply with the string `Hello` as well as set a cookie named `data` to a base64 encoded string representation of the given object.
 
+## Clearing a cookie
+The cookie can be cleared by calling the `unstate()` method on the [`response`](/api#response-object) object:
+
+```javascript
+reply('Hello').unstate('data', { firstVisit: false});
+```
+
 ### Overriding options
 
 When setting a cookie, you may also pass the same options available to `server.state()` as a third parameter, such as:
@@ -53,3 +60,5 @@ When setting a cookie, you may also pass the same options available to `server.s
 ```javascript
 reply('Hello').state('data', 'test', { encoding: 'none' });
 ```
+
+When clearing a cookie, the specified keys in options must match the same keys in the server definition.  

--- a/lib/tutorials/pt_BR/cookies.md
+++ b/lib/tutorials/pt_BR/cookies.md
@@ -50,7 +50,7 @@ Neste exemplo, o hapi irá responder com a string `Hello`, bem como definir um c
 O cookie pode ser eliminado invocando o método `unstate()` no objecto [`response`](/api#response-object):
 
 ```javascript
-reply('Hello').unstate('data', { firstVisit: false });
+reply('Hello').unstate('data');
 ```
 
 ### Sobrescrevendo opções
@@ -60,5 +60,3 @@ Ao definir um cookie, você também pode passar as mesmas opções disponíveis 
 ```javascript
 reply('Hello').state('data', 'test', { encoding: 'none' });
 ```
-
-Ao eliminar um cookie, as opções especificadas têm que ser iguais ás definições que estão no server.

--- a/lib/tutorials/pt_BR/cookies.md
+++ b/lib/tutorials/pt_BR/cookies.md
@@ -50,7 +50,7 @@ Neste exemplo, o hapi irá responder com a string `Hello`, bem como definir um c
 O cookie pode ser eliminado invocando o método `unstate()` no objecto [`response`](/api#response-object):
 
 ```javascript
-reply('Hello').unstate('data', { firstVisit: false});
+reply('Hello').unstate('data', { firstVisit: false });
 ```
 
 ### Sobrescrevendo opções

--- a/lib/tutorials/pt_BR/cookies.md
+++ b/lib/tutorials/pt_BR/cookies.md
@@ -8,7 +8,7 @@ Quando estamos desenvolvendo uma aplicação web, usar cookies é com bastante f
 
 O hapi possui várias opções configuráveis ​​ao lidar com cookies. Os padrões são bons para a maioria dos casos, mas podem ser alterados quando necessário.
 
-Para configurá-los, digite `server.state (nome, opções)` onde `nome` é o nome em string do cookie e `opções` é um objeto usado para configurar o cookie específico.
+Para configurá-los, invoque `server.state(nome, opções)` onde `nome` é o nome em string do cookie e `opções` é um objeto usado para configurar o cookie específico.
 
 ```javascript
 server.state('data', {
@@ -44,12 +44,21 @@ A definição de um cookie é feita através da [interface `reply()`](/api#reply
 reply('Hello').state('data', { firstVisit: false });
 ```
 
-Neste exemplo, o hapi irá responder com a string `Hello`, bem como definir um cookie chamado` data` a uma string codificada em base64 cuja representação é o objetivo especificado. 
+Neste exemplo, o hapi irá responder com a string `Hello`, bem como definir um cookie chamado` data` a uma string codificada em base64 cuja representação é o objetivo especificado.
+
+## Eliminando um cookie
+O cookie pode ser eliminado invocando o método `unstate()` no objecto [`response`](/api#response-object):
+
+```javascript
+reply('Hello').unstate('data', { firstVisit: false});
+```
 
 ### Sobrescrevendo opções
 
-Ao definir um cookie, você também pode passar as mesmas opções disponíveis para `server.state ()` como um terceiro parâmetro, tais como:
+Ao definir um cookie, você também pode passar as mesmas opções disponíveis para `server.state()` como um terceiro parâmetro, tais como:
 
 ```javascript
 reply('Hello').state('data', 'test', { encoding: 'none' });
 ```
+
+Ao eliminar um cookie, as opções especificadas têm que ser iguais ás definições que estão no server.

--- a/lib/tutorials/pt_BR/cookies.md
+++ b/lib/tutorials/pt_BR/cookies.md
@@ -46,17 +46,17 @@ reply('Hello').state('data', { firstVisit: false });
 
 Neste exemplo, o hapi irá responder com a string `Hello`, bem como definir um cookie chamado` data` a uma string codificada em base64 cuja representação é o objetivo especificado.
 
-## Eliminando um cookie
-O cookie pode ser eliminado invocando o método `unstate()` no objecto [`response`](/api#response-object):
-
-```javascript
-reply('Hello').unstate('data');
-```
-
 ### Sobrescrevendo opções
 
 Ao definir um cookie, você também pode passar as mesmas opções disponíveis para `server.state()` como um terceiro parâmetro, tais como:
 
 ```javascript
 reply('Hello').state('data', 'test', { encoding: 'none' });
+```
+
+## Eliminando um cookie
+O cookie pode ser eliminado invocando o método `unstate()` no objecto [`response`](/api#response-object):
+
+```javascript
+reply('Hello').unstate('data');
 ```


### PR DESCRIPTION
It took me a while to get to `response.unset()` as the way to erase a cookie while trying to implement a simple logout handler, adding this info to the cookie tutorial should make it easier for others to find.

Both English and Portuguese translation provided.