### PR TITLE
add hapi-rate-limiter to plugins list

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -425,6 +425,10 @@ exports.categories = {
             url: 'https://github.com/rse/hapi-plugin-header',
             description: 'Always send one or more custom HTTP headers, independent of the current route'
         },
+        'hapi-rate-limiter': {
+            url: 'https://github.com/lob/hapi-rate-limiter/',
+            description: 'A Hapi plugin that enables rate-limiting for GET, POST, and DELETE requests. This plugin can be configured with custom rates on a route-by-route basis.'
+        },
         'hapi-redis': {
             url: 'https://github.com/sandfox/node-hapi-redis',
             description: 'A Hapi plugin to provide a redis client'


### PR DESCRIPTION
Adds [hapi-rate-limiter](https://github.com/lob/hapi-rate-limiter/) to the list of plugins.