### PR TITLE
add hapi-plugin-graphiql: HAPI plugin for integrating GraphiQL, an in…

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -629,6 +629,10 @@ exports.categories = {
             url: 'https://github.com/roylines/hapi-graceful-pm2',
             description: 'Handle true zero downtime reloads when issuing a pm2 gracefulReload command'
         },
+        'hapi-plugin-graphiql': {
+            url: 'https://github.com/rse/hapi-plugin-graphiql',
+            description: 'HAPI plugin for integrating GraphiQL, an interactive GraphQL user interface'
+        },
         hoek: {
             url: 'https://github.com/hapijs/hoek',
             description: 'General purpose node utilities'


### PR DESCRIPTION
This adds "hapi-plugin-graphiql": a HAPI plugin for integrating GraphiQL, an interactive GraphQL user interface. This allows HAPI/GraphQL based servers to deliver their own built-in UI for working with the GraphQL endpoint.