### PR TITLE
Remove private npm website

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -101,10 +101,6 @@ exports.categories = {
             url: 'https://github.com/hueniverse/postmile',
             description: 'Postmile is a collaborative list making tool built using hapi.js, Node.js, and MongoDB.'
         },
-        'npm/newww': {
-            url: 'https://github.com/npm/newww',
-            description: 'The npm website - http://npmjs.com'
-        },
         'Colonizers': {
             url: 'https://github.com/colonizers/colonizers',
             description: 'A HTML5 multiplayer game, based on the popular board game "Catan" by Klaus Teuber.'


### PR DESCRIPTION
The npm website is not public anymore so the link sends to a 404 error page. We should remove the link so people don't get confused about it, right?