### PR TITLE
add hapi-error to list of plugins

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -329,6 +329,10 @@ exports.categories = {
             url: 'https://github.com/christophercliff/hapi-dropbox-webhooks',
             description: 'A Hapi plugin for receiving requests from the Dropbox webhooks API'
         },
+        'hapi-error': {
+            url: 'https://www.npmjs.com/package/hapi-error',
+            description: 'Custom error handling with ability to pass an object and render a custom error template or redirect to a specific url on error.'
+        },
         'hapi-handlers': {
             url: 'https://github.com/ar4mirez/hapi-handlers',
             description: 'Allow to autoload handlers, see more here: http://hapijs.com/api#serverhandlername-method'


### PR DESCRIPTION
Hi `Hapi` People! 
just adding our `error handling` plugin https://www.npmjs.com/package/hapi-error to the list of plugins. thanks. 👍 

> fixes https://github.com/dwyl/hapi-error/issues/30