### PR TITLE
Add hapi-hubspot to plugins listings

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -345,6 +345,10 @@ exports.categories = {
             url: 'https://github.com/briandela/hapi-heroku-helpers',
             description: 'A hapi.js plugin which provides some basic functionality which can be useful when running a hapi.js site on Heroku'
         },
+        'hapi-hubspot': {
+            url: 'https://github.com/asilluron/hapi-hubspot',
+            description: 'Plugin handles initial connection and exposes a single client instance for node-hubspot (a node.js wrapper for HubSpot API)'
+        },
         'hapi-imagemin-proxy': {
             url: 'https://github.com/fhemberger/hapi-imagemin-proxy',
             description: 'Hapi proxy for serving optimized images with `imagemin`'


### PR DESCRIPTION
Add listing for hapi plugin that handles [Hubspot](https://www.hubspot.com/) handshake and initial setup via [Node-Hubspot](https://github.com/brainflake/node-hubspot)