### PR TITLE
add tutorial series to resources

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -150,6 +150,10 @@ exports.categories = {
         'Realtime timeline with hapi.js, nes and RethinkDB': {
             url: 'http://mph-web.de/realtime-timeline-with-hapi-js-nes-and-rethinkdb/',
             description: 'A tutorial that shows how to build a realtime timeline with the nes plugin for hapi.'
+        },
+        'hapi tutorial series (30+ tutorials)': {
+            url: 'https://futurestud.io/tutorials/hapi-get-your-server-up-and-running',
+            description: 'This in-depth tutorial series on hapi covers route setup, authentication, plugins, request & response handling, and much more.'
         }
     },
     'Videos': {


### PR DESCRIPTION
I’ve created a tutorial series on hapi and will extend it continuously. Currently, there are 32 published tutorials and 7 drafts are in the pipeline ready for the publishing. This series helps developers to get started with hapi and also explains advanced topics.