### PR TITLE
add hapi-geo-locate to plugins

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -584,6 +584,10 @@ exports.categories = {
         wurst: {
             url: 'https://github.com/felixheck/wurst',
             description: 'Directory based autoloader for routes'
+        },
+        'hapi-geo-locate': {
+            url: 'https://github.com/fs-opensource/hapi-geo-locate',
+            description: 'Geo locate requests by IP and provide the user’s location in your route handlers'
         }
     },
     Validation: {


### PR DESCRIPTION
add [hapi-geo-locate](https://github.com/fs-opensource/hapi-geo-locate) to list of plugins, category `Utility`. The plugin provides the user’s geo location within route handlers at `request.location`.