### PR TITLE
adding hapi-api-secret-key to plugins

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -207,6 +207,10 @@ exports.categories = {
             url: 'https://github.com/hapijs/crumb',
             description: 'CSRF crumb generation and validation for hapi'
         }
+        'hapi-api-secret-key': {
+            url: 'https://github.com/justin-lovell/hapi-api-secret-key',
+            description: 'Protect your micro-service API by only allowing explicit access with secret tokens. Great for proxies or API Management gateways'
+        }
     },
     'Session': {
         'hapi-server-session': {

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -206,7 +206,7 @@ exports.categories = {
         crumb: {
             url: 'https://github.com/hapijs/crumb',
             description: 'CSRF crumb generation and validation for hapi'
-        }
+        },
         'hapi-api-secret-key': {
             url: 'https://github.com/justin-lovell/hapi-api-secret-key',
             description: 'Protect your micro-service API by only allowing explicit access with secret tokens. Great for proxies or API Management gateways'


### PR DESCRIPTION
A new middleware plugin which I created for API endpoints to ensure that their traffic is only fronted by a gateway such as an API Manager or reverse-proxy.