### PR TITLE
Added mongostore and papertrail good reporters

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -157,6 +157,14 @@ exports.categories = {
             url: 'https://github.com/alexandrebodin/hapi-good-winston',
             description: 'Winston logging for Good process monitor'
         },
+        'hapi-good-papertrail': {
+            url: 'https://github.com/vendigo-group/hapi-good-papertrail',
+            description: 'Papertrail logging reporter for Good'
+        },
+        'hapi-good-mongostore': {
+            url: 'https://github.com/vendigo-group/hapi-good-mongostore',
+            description: 'Good reporter to write to MongoDB'
+        },
         'hapi-statsd': {
             url: 'https://github.com/mac-/hapi-statsd',
             description: 'Sends request round trip metrics to statsd'


### PR DESCRIPTION
- mongostore good reporter facilitates write stream to write in batches to MongoDB.
- Papertrail good reporter will log events to Papertrail, it uses winston-papertrail