### PR TITLE
add hapi-arch to the list of plugins

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -303,6 +303,10 @@ exports.categories = {
             url: 'https://github.com/nathanbuchar/hapi-glee',
             description: 'Specify environment-specific scopes for your routes'
         },
+        'hapi-arch': {
+            url: 'https://github.com/AhmedAli7O1/hapi-arch',
+            description: 'Hapi plugin, with a cli tool to generate MVC hapi project and auto-load almost everything'
+        },
         halacious: {
             url: 'https://github.com/bleupen/halacious',
             description: 'A HAL processor for hapi servers'


### PR DESCRIPTION
[![npm](https://img.shields.io/npm/v/hapi-arch.svg)]() [![npm](https://img.shields.io/npm/dt/hapi-arch.svg)]()

NPM: https://www.npmjs.com/package/hapi-arch

Hapi Arch is a Hapijs plugin, with integrated CLI tool to generate a full MVC Hapi project, including one plugin and it's content e.g controllers, services, models, routes different environment configurations.

once you generate a project using ` hapi-arch generate new ` you'll be able to ` npm install && npm start ` and your server will be available to start hacking.

behind the scene, hapi arch will load all your plugins and it's controllers, services, models..etc and make them available globally " of course on the plugin scope " so you don't need to require anything, plus you got to separate your logic in an MVC way.

also you can blacklist some plugins so arch will not load them " useful in development ".

Hapi Arch, inspired by Rails, Sailsjs and Laravel.

Thanks.