### PR TITLE
add hapi-dev-errors plugin

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -367,6 +367,10 @@ exports.categories = {
             url: 'https://github.com/lob/hapi-default-payload',
             description: 'Hapi plugin to default the request payload to an empty object'
         },
+        'hapi-dev-errors': {
+            url: 'https://github.com/fs-opensource/hapi-dev-errors',
+            description: 'Get better error details during development and skip the command line round trip to catch the issue'
+        },
         'hapi-dropbox-webhooks': {
             url: 'https://github.com/christophercliff/hapi-dropbox-webhooks',
             description: 'A Hapi plugin for receiving requests from the Dropbox webhooks API'


### PR DESCRIPTION
Provide more error details during development and boost productivity by avoiding the round trip to the command line to check the issue. This is disabled by default and requires a boolean value/expression to be activated. This should avoid leaking sensitive information in production.

The plugin renders a web view for browser based requests and replies JSON for REST requests.