### PR TITLE
add hapi-view-models plugin

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -18,6 +18,10 @@ exports.categories = {
         'hapi-rbac': {
             url: 'https://github.com/franciscogouveia/hapi-rbac',
             description: 'A Rule Based Access Control module for hapi'
+        },
+        'hapi-view-models': {
+            url: 'https://github.com/vendigo-group/hapi-view-models',
+            description: 'Filter response payloads based on credentials/roles'
         }
     },
     'Authentication': {
@@ -92,10 +96,6 @@ exports.categories = {
         'hapi-tiny-auth': {
             url: 'https://github.com/elnaz/hapi-tiny-auth',
             description: 'Just enough authentication to make an API private'
-        },
-        'hapi-view-models': {
-            url: 'https://github.com/vendigo-group/hapi-view-models',
-            description: 'Filter response payloads based on credentials/roles'
         }
     },
     'Documentation': {

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -92,6 +92,10 @@ exports.categories = {
         'hapi-tiny-auth': {
             url: 'https://github.com/elnaz/hapi-tiny-auth',
             description: 'Just enough authentication to make an API private'
+        },
+        'hapi-view-models': {
+            url: 'https://github.com/vendigo-group/hapi-view-models',
+            description: 'Filter response payloads based on credentials/roles'
         }
     },
     'Documentation': {


### PR DESCRIPTION
Adds the hapi-view-models plugin we created for filtering payload data based on scopes.