### PR TITLE
Added validation options to tutorials in en_us and pt_br.

### DIFF
--- a/lib/tutorials/en_US/validation.md
+++ b/lib/tutorials/en_US/validation.md
@@ -207,3 +207,32 @@ Because `response.failAction` is not specified, hapi will respond with a `500` e
 The error response will *not* indicate the reason for the error.
 If you have logging configured, you will be able to inspect your error logs for information about what caused the response validation to fail.
 If `response.failAction` were set to `log`, then hapi would respond with the original payload, and log the validation error.
+
+## Options
+
+You can use validation options to show all fields with validate errors.
+See the exemple below:
+
+```javascript
+server.route({
+    method: 'POST',
+    path: '/books',
+    config: {
+        handler: addBook(),
+        validation: {
+            payload: {
+                name: Joi.string().required(),
+                author: Joi.string().required(),
+                price: Joi.string().required()
+            },
+            options: {
+                abortEarly: false
+            }
+        }
+    }
+});
+
+```
+
+Joi has abortEarly as true by default. With this, only the first validation error is returned.
+See more options (here)[https://github.com/hapijs/joi/blob/v10.6.0/API.md#validatevalue-schema-options-callback].

--- a/lib/tutorials/pt_BR/validation.md
+++ b/lib/tutorials/pt_BR/validation.md
@@ -205,3 +205,32 @@ Por quê, `response.failAction` não é especificado, o Hapi irá responder com 
 A resposta de erro *não* indica a razão do erro.
 Se os registros (logging) estiverem configurados, você será capaz de inspecionar os registros de erros sobre a causa da falha na validação da resposta.
 Se `response.failAction` estiver configurada para `log`, então o Hapi irá responder com os dados originais, e registrar o erro na validação.
+
+## Opções
+
+É possivel passar opções para validação, sendo possível, por exemplo, ter uma rota que retorna todos os campos com erros de validação.
+Veja o exemplo abaixo:
+
+```javascript
+server.route({
+    method: 'POST',
+    path: '/books',
+    config: {
+        handler: addBook(),
+        validation: {
+            payload: {
+                name: Joi.string().required(),
+                author: Joi.string().required(),
+                price: Joi.string().required()
+            },
+            options: {
+                abortEarly: false
+            }
+        }
+    }
+});
+
+```
+
+O Joi tem a opção abortEarly como verdadeira por padrão. Com isto, apenas o primeiro erro encontrado é retornado.
+Para mais opções disponíveis, clique (aqui)[https://github.com/hapijs/joi/blob/v10.6.0/API.md#validatevalue-schema-options-callback].


### PR DESCRIPTION
i was boring with the validation, because only first field with error encountered in validation was returned.

So i opened a issue in Joi repo and guys answer me with the option `abortEarly`, who make Joi return all validation erros.

With no documentation about that in hapijs, i read the validation "core", and i discovered an object assign with `options` object at `route.config.validation` object.

Here is the documentation about it :)

PS: Sorry for my english, and maybe is better to do a revision in en_us version.