### PR TITLE
added hapi-redis2 and hapi-mysql2

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -535,6 +535,14 @@ exports.categories = {
             url: 'https://github.com/sandfox/node-hapi-redis',
             description: 'A Hapi plugin to provide a redis client'
         },
+        'hapi-redis2': {
+            url: 'https://github.com/midnightcodr/hapi-redis2',
+            description: 'A redis plugin for Hapijs that supports multiple connections, inspired by Marsup/hapi-mongodb'
+        },
+        'hapi-mysql2': {
+            url: 'https://github.com/midnightcodr/hapi-mysql2',
+            description: 'Another mysql plugin for Hapijs that supports multiple connections, inspired by Marsup/hapi-mongodb'
+        },
         'hapi-response-time': {
             url: 'https://github.com/pankajpatel/hapi-response-time',
             description: 'A Hapi plugin for adding `x-response-time` header to responses'

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -483,6 +483,10 @@ exports.categories = {
             url: 'https://github.com/metoikos/hapi-multi-mongo',
             description: 'Hapi mongodb connection plugin, especially for multiple connections'
         },
+        'hapi-mysql2': {
+            url: 'https://github.com/midnightcodr/hapi-mysql2',
+            description: 'Another mysql plugin for Hapijs that supports multiple connections, inspired by Marsup/hapi-mongodb'
+        },
         'hapi-named-routes': {
             url: 'https://github.com/poeticninja/hapi-named-routes',
             description: 'Add named routes to your view templates'
@@ -538,10 +542,6 @@ exports.categories = {
         'hapi-redis2': {
             url: 'https://github.com/midnightcodr/hapi-redis2',
             description: 'A redis plugin for Hapijs that supports multiple connections, inspired by Marsup/hapi-mongodb'
-        },
-        'hapi-mysql2': {
-            url: 'https://github.com/midnightcodr/hapi-mysql2',
-            description: 'Another mysql plugin for Hapijs that supports multiple connections, inspired by Marsup/hapi-mongodb'
         },
         'hapi-response-time': {
             url: 'https://github.com/pankajpatel/hapi-response-time',


### PR DESCRIPTION
I created these two plugins because it's not easy to use the exiting `hapi-redis` and `hapi-mysql` plugins to handle situations where multiple connections are required.