### PR TITLE
Only show section anchors when hovered

### DIFF
--- a/public/css/sections/github.styl
+++ b/public/css/sections/github.styl
@@ -5,6 +5,9 @@
 .page-api
   h1, h2, h3, h4, h5, h6
     position: relative
+    
+    a.anchor
+      display: none
 
   h1:hover a.anchor,
   h2:hover a.anchor,


### PR DESCRIPTION
Currently, section anchors are always displayed which makes them jump to the left by `20px` when the header is hovered.