### PR TITLE
Add new hapi-cron-cluster plugin

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -327,7 +327,7 @@ exports.categories = {
             url: 'https://github.com/antonsamper/hapi-cron',
             description: 'Cron jobs for internal hapi.js routes'
         },
-        cron-cluster: {
+        'cron-cluster': {
             url: 'https://github.com/Meg4mi/hapi-cron-cluster',
             description: 'Cron jobs for internal hapi.js routes with leader election (mongodb or redis) - cluster mode'
         },

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -327,6 +327,10 @@ exports.categories = {
             url: 'https://github.com/antonsamper/hapi-cron',
             description: 'Cron jobs for internal hapi.js routes'
         },
+        cron-cluster: {
+            url: 'https://github.com/Meg4mi/hapi-cron-cluster',
+            description: 'Cron jobs for internal hapi.js routes with leader election (mongodb or redis) - cluster mode'
+        },
         crudy: {
             url : 'https://github.com/g-div/crudy',
             description: 'Exposes a RESTful CRUD interface using Dogwater models and Bedwetter\'s route-handler'


### PR DESCRIPTION
Add new hapi-cron-cluster plugin
 url: 'https://github.com/Meg4mi/hapi-cron-cluster',
 description: 'Cron jobs for internal hapi.js routes with leader election (mongodb or redis) - cluster mode'