### PR TITLE
add hapi-moon boilerplate to resources

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -67,6 +67,10 @@ exports.categories = {
             url: 'https://github.com/smaxwellstewart/hapi-dash',
             description: 'A boilerplate hapi web and API server example, with frontend dashboard'
         },
+        'hapi-moon': {
+            url: 'https://github.com/metoikos/hapi-moon',
+            description: 'Opinionated Hapi.js (V >= 17) Server Boilerplate'
+        },
         'hapi-ninja': {
             url: 'https://github.com/poeticninja/hapi-ninja',
             description: 'Boilerplate hapi server example. Node.js, hapi, and Swig.'

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -69,7 +69,7 @@ exports.categories = {
         },
         'hapi-moon': {
             url: 'https://github.com/metoikos/hapi-moon',
-            description: 'Opinionated Hapi.js (V >= 17) Server Boilerplate'
+            description: 'Opinionated hapi.js (V >= 17) Server Boilerplate'
         },
         'hapi-ninja': {
             url: 'https://github.com/poeticninja/hapi-ninja',


### PR DESCRIPTION
Another opinionated hapi.js boilerplate, works with v17.