### PR TITLE
Update sequelize plugin

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -583,8 +583,8 @@ exports.categories = {
             url: 'https://github.com/lob/hapi-sanitize-payload',
             description: 'Hapi plugin to sanitize the request payload'
         },
-        'hapi-sequelize': {
-            url: 'https://github.com/danecando/hapi-sequelize',
+        'hapi-sequelizejs': {
+            url: 'https://github.com/valtlfelipe/hapi-sequelizejs',
             description: 'Hapi plugin for the fabulous Sequelize ORM'
         },
         'hapi-sequelize-crud': {


### PR DESCRIPTION
Change sequelize plugin to a updated fork with support to latest versions of hapi and sequelize