### PR TITLE
Fix slack invite link

### DIFF
--- a/lib/tutorials/en_US/getting-started.md
+++ b/lib/tutorials/en_US/getting-started.md
@@ -229,4 +229,4 @@ Great! This is just one short example of what plugins are capable of, for more i
 
 ### Everything else
 
-hapi has many, many other capabilities and only a select few are documented in tutorials here. Please use the list to your right to check them out. Everything else is documented in the [API reference](/api) and, as always, feel free to ask questions on [github](https://github.com/hapijs/discuss/issues) and [gitter](https://gitter.im/hapijs/hapi) or just visit us on [slack](https://t.co/RLLcGIGmRZ).
+hapi has many, many other capabilities and only a select few are documented in tutorials here. Please use the list to your right to check them out. Everything else is documented in the [API reference](/api) and, as always, feel free to ask questions on [github](https://github.com/hapijs/discuss/issues) and [gitter](https://gitter.im/hapijs/hapi) or just visit us on [slack](https://join.slack.com/t/hapihour/shared_invite/enQtMjM5Njk1NDgzNTY5LThmODkxODIzOTg5NjJjODFiYjcxZDMxMTAyMzBkZDk3MWY4MTFlNDAyMTU3MmUwMmM0Y2UwMjU3YjAwYjRkN2E).

--- a/templates/index.pug
+++ b/templates/index.pug
@@ -44,7 +44,7 @@ block content
 
       p Visit us on IRC in <a href='http://webchat.freenode.net/?channels=hapi'>#hapi</a> on <a href='http://freenode.net'>freenode</a>.
 
-      p Join us on Slack at <a href='https://hapihour.slack.com'>hapihour.slack.com</a> (<a href='https://hapihour.slack.com/join/shared_invite/enQtMjM5Njk1NDgzNTY5LThmODkxODIzOTg5NjJjODFiYjcxZDMxMTAyMzBkZDk3MWY4MTFlNDAyMTU3MmUwMmM0Y2UwMjU3YjAwYjRkN2E'>First time? Join here</a>).
+      p Join us on Slack at <a href='https://hapihour.slack.com'>hapihour.slack.com</a> (<a href='https://join.slack.com/t/hapihour/shared_invite/enQtMjM5Njk1NDgzNTY5LThmODkxODIzOTg5NjJjODFiYjcxZDMxMTAyMzBkZDk3MWY4MTFlNDAyMTU3MmUwMmM0Y2UwMjU3YjAwYjRkN2E'>First time? Join here</a>).
     section.bottom-rule.getting-started
       h2 Getting started
       p Start by creating a


### PR DESCRIPTION
The shortened slack invite link expired.  See https://github.com/hapijs/discuss/issues/646