### PR TITLE
Added hapi-openapi

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -771,6 +771,10 @@ exports.categories = {
             url: 'https://github.com/roylines/hapi-graceful-pm2',
             description: 'Handle true zero downtime reloads when issuing a pm2 gracefulReload command'
         },
+        'hapi-openapi': {
+            url: 'https://github.com/krakenjs/hapi-openapi',
+            description: 'Hapi plugin to build design-driven apis with OpenAPI (formerly swagger).'
+        },
         'hapi-plugin-graphiql': {
             url: 'https://github.com/rse/hapi-plugin-graphiql',
             description: 'HAPI plugin for integrating GraphiQL, an interactive GraphQL user interface'

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -773,7 +773,7 @@ exports.categories = {
         },
         'hapi-openapi': {
             url: 'https://github.com/krakenjs/hapi-openapi',
-            description: 'Hapi plugin to build design-driven apis with OpenAPI (formerly swagger).'
+            description: 'hapi plugin to build design-driven apis with OpenAPI (formerly swagger).'
         },
         'hapi-plugin-graphiql': {
             url: 'https://github.com/rse/hapi-plugin-graphiql',


### PR DESCRIPTION
Added `hapi-openapi` — a plugin for building design-driven OpenAPI apis.

I didn't add this under 'Documenting' because this plugin uses the API specification to create the routes, security, etc, as well as the documentation.