### PR TITLE
add hapi-request-user plugin

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -559,6 +559,10 @@ exports.categories = {
             url: 'https://github.com/midnightcodr/hapi-redis2',
             description: 'A redis plugin for Hapijs that supports multiple connections, inspired by Marsup/hapi-mongodb'
         },
+        'hapi-request-user': {
+            url: 'https://github.com/fs-opensource/hapi-request-user',
+            description: 'A hapi plugin that shortcuts “request.auth.credentials” to “request.user”'
+        },
         'hapi-response-time': {
             url: 'https://github.com/pankajpatel/hapi-response-time',
             description: 'A Hapi plugin for adding `x-response-time` header to responses'


### PR DESCRIPTION
Add `hapi-request-user` to hapi plugin list.

A plugin that shortcuts `request.auth.credentials` to `request.user`.