### PR TITLE
Fix typo in Contributing page

### DIFF
--- a/templates/contribute.pug
+++ b/templates/contribute.pug
@@ -7,7 +7,7 @@ block content
 
   section.bottom-rule.contributing
     .content
-      h3 Contibuting to hapi
+      h3 Contributing to hapi
       p If you're interested in helping out, here's a list of currently open issues that would be a great place to start. Make sure to read the <a href="/styleguide">style guide</a> before you write any code. For further information about the hapijs community, see the <a href="/governance">governance</a> and <a href="/operating">operating guidelines</a>.
 
       .cf


### PR DESCRIPTION
Fixing a small typo

<img width="1221" alt="screen shot 2018-04-05 at 3 29 36 pm" src="https://user-images.githubusercontent.com/3230529/38395126-4624134c-38e6-11e8-95dc-1e8dc0157b4c.png">
