### PR TITLE
move menu getting start to top

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -108,12 +108,16 @@ module.exports = (server) => {
                     tutorial = Tutorials[language].default;
                 }
 
+                const menus = Tutorials[language].all;
+                const firstItem = 'getting-started';
+                const item = menus.filter(({ slug }) => slug === firstItem);
+                // add getting started on first position men
+                const all = item.concat(menus.filter(({ slug }) => slug !== firstItem));
                 const html = await request.server.methods.markdown.parse(tutorial.contents);
-
                 const context = {
                     languages: Tutorials.languages,
                     language,
-                    tutorials: Tutorials[language].all,
+                    tutorials: all,
                     active: tutorial.title,
                     html
                 };

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -110,9 +110,9 @@ module.exports = (server) => {
 
                 const menus = Tutorials[language].all;
                 const firstItem = 'getting-started';
-                const item = menus.filter(({ slug }) => slug === firstItem);
+                const item = menus.find(({ slug }) => slug === firstItem);
                 // add getting started on first position men
-                const all = item.concat(menus.filter(({ slug }) => slug !== firstItem));
+                const all = [item].concat(menus.filter(({ slug }) => slug !== firstItem));
                 const html = await request.server.methods.markdown.parse(tutorial.contents);
                 const context = {
                     languages: Tutorials.languages,


### PR DESCRIPTION
Signed-off-by: Erick Wendel <erick.workspace@gmail.com>

An observation: 

When that project calls GitHub api, with  `authorization: token `,  the API is refusing and returning 401, without `token` word, Github's api works fine. It happens on `gitHub.js` and `markdown.js` from `lib`

I think that production token is different so, I don't change api calls, only change menu.

from #582 