### PR TITLE
Remove bucker from logging suggestions - it appears to be obsolete

### DIFF
--- a/lib/tutorials/en_US/logging.md
+++ b/lib/tutorials/en_US/logging.md
@@ -70,4 +70,4 @@ You can find more information on debug mode in the [API documentation](https://h
 
 ## Logging plugins
 
-The built-in methods provided by hapi for retrieving and printing logs are fairly minimal. For a more feature-rich logging experience, you can look into using a plugin like [good](https://github.com/hapijs/good) or [bucker](https://github.com/nlf/bucker).
+The built-in methods provided by hapi for retrieving and printing logs are fairly minimal. For a more feature-rich logging experience, you can look into using a plugin like [good](https://github.com/hapijs/good).

--- a/lib/tutorials/pt_BR/logging.md
+++ b/lib/tutorials/pt_BR/logging.md
@@ -1,6 +1,6 @@
 ## Métodos nativos
 
-Como todo programa de servidor, o log é muito importante. O Hapi possui alguns métodos nativos de log, bem como uma capacidade limitada para visualização destes logs.  
+Como todo programa de servidor, o log é muito importante. O Hapi possui alguns métodos nativos de log, bem como uma capacidade limitada para visualização destes logs.
 
 Existem dois métodos bem parecidos de log, `server.log`, e `request.log`. A diferença entre os dois está em qual evento eles emitem, qual objeto emite o evento, e qual dado é automaticamente associado. O método `server.log` emite um evento de `log` no server, e possui a URI do server associada a ele. O `request.log` emite um evento de `request` no `server` e tem o id interno da requisição (`request`) associado a ele.
 
@@ -31,4 +31,4 @@ const server = new Hapi.Server({ debug: { request: ['error'] } });
 
 ## Plugins de log
 
-Os métodos nativos são mínimos, no entando, para um log mais completo você realmente deveria pensar em usar um plugin como [good](https://github.com/hapijs/good) or [bucker](https://github.com/nlf/bucker).
+Os métodos nativos são mínimos, no entando, para um log mais completo você realmente deveria pensar em usar um plugin como [good](https://github.com/hapijs/good).


### PR DESCRIPTION
Hasn't been maintained since 2015, still invites users to load it using
pack.require().

I have not updated the Korean language instance of this page because my
Korean isn't up to that. Also, someone with knowledge of Portugese should
review my change.

Also remove trailing whitespace.