### PR TITLE
Add hapi-rate-limitor and hapi-pulse plugins 

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -726,6 +726,14 @@ exports.categories = {
         wurst: {
             url: 'https://github.com/felixheck/wurst',
             description: 'Directory based autoloader for routes'
+        },
+        'hapi-pulse': {
+            url: 'https://github.com/fs-opensource/hapi-pulse',
+            description: 'Gracefully stop the hapi server on SIGINT (for graceful PM2 reloads)'
+        },
+        'hapi-rate-limitor': {
+            url: 'https://github.com/fs-opensource/hapi-rate-limitor',
+            description: 'Easy to use rate limiting to prevent brute-force attacks'
         }
     },
     Validation: {


### PR DESCRIPTION
This PR adds two hapi utility plugins to the community list

- [hapi-rate-limitor](https://github.com/fs-opensource/hapi-rate-limitor)
- [hapi-pulse](https://github.com/fs-opensource/hapi-pulse)