### PR TITLE
Update to hapi-pino logging example

### DIFF
--- a/lib/tutorials/en_US/getting-started.md
+++ b/lib/tutorials/en_US/getting-started.md
@@ -207,7 +207,7 @@ const init = async () => {
     await server.register({
         plugin: require('hapi-pino'),
         options: {
-            prettyPrint: false,
+            prettyPrint: true,
             logEvents: ['response', 'onPostStart']
         }
     });


### PR DESCRIPTION
The output shown in the example is actually 'pretty printed' while the plugin registration shows prettyPrint set to `false`.