### PR TITLE
Rename "new contributor" label to "good first issue"

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -244,7 +244,7 @@ exports.methods.push({
     method: async function (request) {
 
         const params = Querystring.encode({
-            labels: 'new contributor'
+            labels: 'good first issue'
         });
 
         const repos = request.pre.repos.filter((repo) => repo.open_issues > 0).map((repo) => repo.name);

--- a/templates/contribute.pug
+++ b/templates/contribute.pug
@@ -16,7 +16,7 @@ block content
         .column.new-contributor-issues
           header.cf
             h4.pull-left Issues for new contributors
-            a.pull-right(href='https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Ahapijs+label%3A%22new+contributor%22+', title='See all issues for new contributors') See all
+            a.pull-right(href='https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Ahapijs+label%3A%22good+first+issue%22+', title='See all issues for new contributors') See all
 
           ul.unstyled
             each issue in newContributorIssues.slice(0, 20)


### PR DESCRIPTION
Per https://github.com/hapijs/contrib/issues/123, we're renaming the `new contributor` label to `good first issue`, so the "contribute" page needs a little update.

I will wait for this to get approved, but please leave it to me to merge—I will merge this in sync with the actual update to each repo's labels.