### PR TITLE
Updates hapi-auto-route's informations

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -388,8 +388,8 @@ exports.categories = {
             description: 'An hapi.js plugin that limits the number of failed attempts for every route'
         },
         'hapi-auto-route': {
-            url: 'https://github.com/sitrakay/hapi-auto-route',
-            description: 'Autoloads routes object from a directory'
+            url: 'https://github.com/hsitraka/hapi-auto-route',
+            description: 'Automatically load routes from directory'
         },
         'hapi-aws': {
             url: 'https://github.com/ar4mirez/hapi-aws',


### PR DESCRIPTION
The repository was moved to https://github.com/hsitraka/hapi-auto-route.