### PR TITLE
Add @podium/hapi-layout and @podium/hapi-podlet plugins

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -863,6 +863,14 @@ exports.categories = {
             url: 'https://github.com/hapijs/nes',
             description: 'WebSocket adapter plugin for hapi routes'
         },
+        'podium-hapi-layout': {
+            url: 'https://github.com/podium-lib/hapi-layout',
+            description: 'Hapi plugin for writing Micro Frontend Layout servers with Podium - https://podium-lib.io'
+        },
+        'podium-hapi-podlet': {
+            url: 'https://github.com/podium-lib/hapi-podlet',
+            description: 'Hapi plugin for writing Micro Frontend Fragment servers with Podium - https://podium-lib.io'
+        },
         qs: {
             url: 'https://github.com/hapijs/qs',
             description: 'A querystring parser with support for arrays and objects'


### PR DESCRIPTION
[Podium](https://podium-lib.io/) is framework for writing [Micro Frontends](https://micro-frontends.org/). Podium version 3.0.0 is http framework agnostic and can now be used with multiple http frameworks, including Hapi.

This adds the plugins for writing Podium layout and fragment servers with Hapi:

 - https://github.com/podium-lib/hapi-layout
 - https://github.com/podium-lib/hapi-podlet

NB: Currently the documentation on Podium only reference Express, but will shortly also include examples for Hapi and other http frameworks.