### PR TITLE
Tiny update to plugins.md for one of the examples.

### DIFF
--- a/lib/tutorials/en_US/plugins.md
+++ b/lib/tutorials/en_US/plugins.md
@@ -158,7 +158,7 @@ exports.plugin = {
 Normally, when this plugin is loaded it will create a `GET` route at `/test`. This can be changed by using the `prefix` setting in the options, which will prepend a string to all routes created in the plugin:
 
 ```javascript
-const start = async function () {
+const start = async function (server) {
 
     await server.register(require('myplugin'), {
         routes: {


### PR DESCRIPTION
Just looks like the last example is missing the `server` param in the function. This adds that to the example code.