### PR TITLE
Fix example in Authorization tutorial

### DIFF
--- a/lib/tutorials/en_US/auth.md
+++ b/lib/tutorials/en_US/auth.md
@@ -243,7 +243,7 @@ const start = async () => {
                                 <title>Login page</title>
                             </head>
                             <body>
-                                <h3>Please Log In</h3
+                                <h3>Please Log In</h3>
                                 <form method="post" action="/login">
                                     Username: <input type="text" name="username"><br>
                                     Password: <input type="password" name="password"><br/>


### PR DESCRIPTION
Add a closing angle bracket to a h3 tag. In the example for the "hapi-auth-cookie" section Authentication, the h3 tag is missing a closing angle bracket.