### PR TITLE
update hapi-sequelizejs description

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -611,7 +611,7 @@ exports.categories = {
         },
         'hapi-sequelizejs': {
             url: 'https://github.com/valtlfelipe/hapi-sequelizejs',
-            description: 'HAPI Plugin for Sequelize (compatible v17)'
+            description: 'A Hapi plugin for Sequelize ORM'
         },
         'hapi-sequelize-crud': {
             url: 'https://github.com/mdibaiee/hapi-sequelize-crud',


### PR DESCRIPTION
I'm the maintainer of `hapi-sequelizejs` and wanted to update the description, to match the latest releases of the plugin, that already supports sequelize v18