### PR TITLE
Methods cache

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -27,14 +27,17 @@ exports.methods.push({
 
 exports.methods.push({
     name: 'npm.version',
-    method: async () => {
+    method: async (req) => {
 
-        const result = await Utils.download('https://registry.npmjs.org/@hapi/hapi', { json: true, rejectUnauthorized: false });
-        return result && result['dist-tags'] && result.versions && result['dist-tags'].latest && result.versions[result['dist-tags'].latest];
+        const result = await req.server.methods.npm.package('@hapi/hapi');
+        return result.versions[result['dist-tags'].latest];
     },
     options: {
         cache: {
-            expiresIn: Utils.fifteenMinutes,
+            dropOnError: false,
+            expiresIn: Utils.oneDay,
+            staleIn: Utils.fifteenMinutes,
+            staleTimeout: Utils.fiveSeconds,
             generateTimeout: Utils.oneMinute
         },
         generateKey: () => 'npm.version'
@@ -59,7 +62,10 @@ exports.methods.push({
     },
     options: {
         cache: {
-            expiresIn: Utils.fifteenMinutes,
+            dropOnError: false,
+            expiresIn: Utils.oneDay,
+            staleIn: Utils.fifteenMinutes,
+            staleTimeout: Utils.fiveSeconds,
             generateTimeout: Utils.oneMinute
         },
         generateKey: () => 'npm.versions'
@@ -78,7 +84,9 @@ exports.methods.push({
     },
     options: {
         cache: {
-            expiresIn: Utils.oneDay,
+            expiresIn: 7 * Utils.oneDay,
+            staleIn: Utils.oneDay,
+            staleTimeout: Utils.fiveSeconds,
             generateTimeout: Utils.oneMinute
         },
         generateKey: () => 'npm.downloads'

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -5,6 +5,27 @@ const Utils =  require('./utils');
 exports.methods = [];
 
 exports.methods.push({
+    name: 'npm.package',
+    method: async (packageName) => {
+
+        const result = await Utils.download(`https://registry.npmjs.org/${packageName}`, { json: true, rejectUnauthorized: false });
+        if (!result || result.name !== packageName) {
+            throw new Error(`failed to fetch package ${packageName}`);
+        }
+        return result;
+    },
+    options: {
+        cache: {
+            dropOnError: false,
+            expiresIn: Utils.oneDay,
+            staleIn: Utils.fifteenMinutes,
+            staleTimeout: Utils.fiveSeconds,
+            generateTimeout: Utils.oneMinute
+        }
+    }
+});
+
+exports.methods.push({
     name: 'npm.version',
     method: async () => {
 
@@ -20,10 +41,22 @@ exports.methods.push({
     }
 });
 
-
 exports.methods.push({
     name: 'npm.versions',
-    method: () => Utils.download('https://registry.npmjs.org/@hapi/hapi', { json: true, rejectUnauthorized: false }),
+    method: async (req) => {
+
+        const result = await req.server.methods.npm.package('@hapi/hapi');
+
+        try {
+            const resultLegacy = await req.server.methods.npm.package('hapi');
+            result.versions = Object.assign(resultLegacy.versions, result.versions);
+        }
+        catch (error) {
+            req.log(['error'], { msg: 'failed to fetch legacy package info from npm', error });
+        }
+
+        return result;
+    },
     options: {
         cache: {
             expiresIn: Utils.fifteenMinutes,
@@ -32,9 +65,6 @@ exports.methods.push({
         generateKey: () => 'npm.versions'
     }
 });
-
-
-
 
 exports.methods.push({
     name: 'npm.downloads',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -68,6 +68,7 @@ exports.downloadAllPages = async function (url, perPage, options) {
     return result;
 };
 
+exports.fiveSeconds = 5000;
 exports.oneMinute = 60000;
 exports.fifteenMinutes = 900000;
 exports.oneHour = 3600000;

--- a/templates/index.pug
+++ b/templates/index.pug
@@ -14,11 +14,11 @@ block header
         h4 hapi enables developers to focus on writing reusable application logic instead of spending time building infrastructure.
 
         .latest-update
-          small Current version: <a href='https://github.com/hapijs/hapi/tags'>#{version.version}</a>
+          small Current version: <a href='https://github.com/hapijs/hapi/tags'>#{version && version.version || 'N/A'}</a>
           small  ● Latest update:
-          small  <a href="#{latestUpdate.url}" role="update">#{latestUpdate.updated}</a>
+          small  <a href="#{latestUpdate.url}" role="update">#{latestUpdate && latestUpdate.updated || 'N/A'}</a>
           small  ● Downloads last month:
-          small  <a href="http://npm-stat.com/charts.html?package=hapi">#{downloads}</a>
+          small  <a href="http://npm-stat.com/charts.html?package=hapi">#{downloads || 'N/A'}</a>
 
 block content
 


### PR DESCRIPTION
Following discussion from #714

I updated the templates to show 'N/A' if data is not available.

I looked into caching and it seem like the only way to get a cached result returned is by throwing an error.

This is a bit risky since if the cache is unavailable (first fetch) or expired the error will propagate and the server will return a 500 response.
If cache is available it will use it's value instead.

I increased the expiry value and added stale values so data will still be fresh so I think the risk of not having a valid data in cache is really small but it can happen.

I also found a minor bug where the old code specifically checked for latest v16 to display it in the dropdown for API docs.
This obviously failed when moving to `@hapi/hapi` since v16 is not published there.
I added a small workaround to also fetch the version from the old package but if we don't think the v16 API is still relevant maybe this can be removed