### PR TITLE
improve: npm-stat link to show stats for both @hapi/hapi and hapi

### DIFF
--- a/templates/index.pug
+++ b/templates/index.pug
@@ -18,7 +18,7 @@ block header
           small  ● Latest update:
           small  <a href="#{latestUpdate.url}" role="update">#{latestUpdate.updated}</a>
           small  ● Downloads last month:
-          small  <a href="http://npm-stat.com/charts.html?package=hapi">#{downloads}</a>
+          small  <a href="http://npm-stat.com/charts.html?package=@hapi/hapi%2Chapi">#{downloads}</a>
 
 block content
 


### PR DESCRIPTION
Link on home page goes to http://npm-stat.com/charts.html?package=hapi which shows download stats for old package.
Change to show both package stats.
We'll probably want to switch to only show @hapi/hapi once it picks up.
