### PR TITLE
Change test pattern to **/*.test.js for testing md

### DIFF
--- a/lib/tutorials/en_US/testing.md
+++ b/lib/tutorials/en_US/testing.md
@@ -134,6 +134,6 @@ To run the tests, you can modify the `package.json` of your project to run your 
 
 ```json
   "scripts": {
-    "test": "lab -v **/*.spec.js"
+    "test": "lab -v **/*.test.js"
   }
 ```


### PR DESCRIPTION
This changes make the docs consistent since, in the code example we use example.test.js

See [this line](https://github.com/hapijs/hapijs.com/compare/master...empeje:patch-1#diff-9d2deffeac6107079872300530c85f1fL95) for my reasoning.