### PR TITLE
fixing cookie auth example code

### DIFF
--- a/lib/tutorials/en_US/auth.md
+++ b/lib/tutorials/en_US/auth.md
@@ -265,15 +265,18 @@ const start = async () => {
                     (user) => user.username === username
                 );
 
-                if (!account || !(await Bcrypt.compare(password, user.password))) {
+                if (!account || !(await Bcrypt.compare(password, account.password))) {
 
                     return h.view('/login');
         }
 
-                request.cookieAuth.set({ id: user.id });
+                request.cookieAuth.set({ id: account.id });
 
                 return h.redirect('/');
-             }
+            },
+            options: {
+                auth: false
+            }
         }
     ]);
 


### PR DESCRIPTION
In going through the auth examples, I came across a couple issues with the cookie code.

1. add `auth:false` to the login POST route. Otherwise kept getting a 302 back to login GET
2. access `id` and `password` from account object instead of non-existing-in-scope user object